### PR TITLE
Get last timestamp

### DIFF
--- a/src/extraction/get_last_timestamp.py
+++ b/src/extraction/get_last_timestamp.py
@@ -1,0 +1,18 @@
+import boto3
+from botocore.exceptions import ClientError 
+
+def get_last_timestamp(parameter_name):
+    '''Returns the last time at which the AWS lambda was triggered.'''
+
+    try:
+        conn = boto3.client('ssm', region_name='eu-west-2')
+        response = conn.get_parameter(
+        Name=parameter_name
+        )
+        return response['Parameter']['Value']
+    except ClientError as err:
+        if err.response['Error']['Code'] == 'ParameterNotFound':
+            return None
+
+def write_last_timestamp():
+    pass

--- a/src/extraction/last_timestamp.py
+++ b/src/extraction/last_timestamp.py
@@ -1,0 +1,25 @@
+import boto3
+from datetime import datetime
+
+
+def get_last_timestamp(parameter_name):
+    '''Returns the last time at which the AWS lambda was triggered.'''
+    conn = boto3.client('ssm', region_name='eu-west-2')
+    response = conn.get_parameter(
+        Name=parameter_name
+    )
+    last_timestamp = response['Parameter']['Value']
+    return datetime.strptime(last_timestamp, '%Y-%m-%d %H:%M:%S')
+
+
+def write_current_timestamp(parameter_name, current_time):
+    '''Writes the current time to AWS parameters'''
+    formatted_time = current_time.isoformat(sep=' ', timespec='auto')
+    conn = boto3.client('ssm', region_name='eu-west-2')
+    response = conn.put_parameter(
+            Name=parameter_name,
+            Value=formatted_time,
+            Type='String',
+            Overwrite=True
+    )
+    return response

--- a/tests/test_extraction/test_get_last_timestamp.py
+++ b/tests/test_extraction/test_get_last_timestamp.py
@@ -1,0 +1,133 @@
+from moto import mock_cloudwatch, mock_logs, mock_ssm
+import pytest
+import boto3
+import os
+from unittest.mock import patch
+from botocore.exceptions import ClientError
+from src.extraction.get_last_timestamp import (
+    get_last_timestamp
+)
+from datetime import datetime
+
+
+@pytest.fixture(scope="function")
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "test"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "test"
+    os.environ["AWS_SECURITY_TOKEN"] = "test"
+    os.environ["AWS_SESSION_TOKEN"] = "test"
+    os.environ["AWS_DEFAULT_REGION"] = "eu-west-2"
+
+@pytest.fixture(scope="function")
+def mock_params(aws_credentials):
+    with mock_ssm():
+        yield boto3.client("ssm", region_name="eu-west-2")
+
+class TestGetLastTimestamp:
+    def test_returns_value_if_parameter_found(self, mock_params):
+        test_name = 'Test-parameter'
+        test_value = '2023-01-02'
+        response = mock_params.put_parameter(
+            Name=test_name,
+            Value='2023-01-02',
+            Overwrite=True,
+        )
+        assert get_last_timestamp(test_name) == test_value
+
+    def test_returns_none_if_parameter_not_found(self, mock_params):
+        test_name = 'Test-parameter'
+   
+        assert get_last_timestamp(test_name) == None
+
+
+# @pytest.fixture(scope="function")
+# def mock_logger(aws_credentials):
+#     with mock_logs():
+#         yield boto3.client("logs", region_name="eu-west-2")
+
+        # response = mock_params.get_parameter(
+        #     Name='Test-parameter'
+        # )
+        # print(response['Parameter']['Value'])
+        # response = mock_params.put_parameter(
+        #     Name='Test-parameter',
+        #     Value='2024-01-02',
+        #     Overwrite=True,
+        # )
+        # response = mock_params.get_parameter(
+        #     Name='Test-parameter'
+        # )
+        # print(response['Parameter']['Value'])
+        # response_time = response['Parameter']['Value']
+        # print(datetime.now())
+        # last_time = datetime.strptime(response_time, '%Y-%m-%d')
+        # print(last_time)
+
+# def test_returns_log(mock_logger):
+    
+#     mock_logger.create_log_group(logGroupName='test-group')
+#     #print(response, '<<<< create log group')
+
+#     mock_logger.create_log_stream(logGroupName='test-group',
+#     logStreamName='test-stream-1'
+#     )
+#     mock_logger.create_log_stream(logGroupName='test-group',
+#     logStreamName='test-stream-2'
+#     )
+
+#     mock_logger.put_retention_policy(
+#         logGroupName='test-group',
+#         retentionInDays=1
+#     )
+
+#     log_stream_list = mock_logger.describe_log_streams(
+#         logGroupName='test-group'
+#     )
+#     print(log_stream_list['logStreams'][0])
+#     log_stream_name_1 = log_stream_list['logStreams'][0]['logStreamName']
+#     log_stream_name_2 = log_stream_list['logStreams'][1]['logStreamName']
+#     print(log_stream_name_1)
+#     print(log_stream_name_2)
+
+#     # print(log_stream_name, '<<<<< stream name')
+#     #print(response, '<<<< create log stream')
+#     response = mock_logger.put_log_events(
+#             logGroupName='test-group',
+#             logStreamName=log_stream_name_1,
+#             logEvents=[
+#                 {
+#                     "timestamp": 1698933550,
+#                     "message": "Hello World"
+#                 }
+#             ],
+#             sequenceToken='aaa'
+#         )
+
+#     response_2 = mock_logger.get_log_events(
+#         logGroupName='test-group',
+#         logStreamName=log_stream_name_1,
+#         startTime=1698933540,
+#         endTime=1798933540
+#     )
+#     print(response_2['events'], '<<< Response 2')
+    # print(dir(response_2), '<<<<<< get log event')
+    # print(response_2.values(), '<<<<<< get log event')
+    # def switch_log(string):
+    #     print('Little_Oysters')
+    #     response = mock_log.put_log_events(logGroupName='test_group',
+    #          logStreamName='stringNCrandom',
+    #                            logEvents=[
+    #     #                             {
+    #                                 'timestamp': 123,
+    #                                 'message': string
+    #                             }
+    #                             ],
+    #     )
+        
+
+    # logger = logging.getLogger('test')
+    # monkeypatch.setattr(logger, "info", switch_log)
+    # logger.setLevel(logging.INFO)
+    # logger.propagate = True
+    # logger.info('This is a test event')

--- a/tests/test_extraction/test_last_timestamp.py
+++ b/tests/test_extraction/test_last_timestamp.py
@@ -1,0 +1,76 @@
+from moto import mock_ssm
+import pytest
+import boto3
+from botocore.exceptions import ClientError
+import os
+from datetime import datetime
+from src.extraction.last_timestamp import (
+    get_last_timestamp,
+    write_current_timestamp,
+)
+
+
+@pytest.fixture(scope="function")
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "test"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "test"
+    os.environ["AWS_SECURITY_TOKEN"] = "test"
+    os.environ["AWS_SESSION_TOKEN"] = "test"
+    os.environ["AWS_DEFAULT_REGION"] = "eu-west-2"
+
+
+@pytest.fixture(scope="function")
+def mock_params(aws_credentials):
+    with mock_ssm():
+        yield boto3.client("ssm", region_name="eu-west-2")
+
+
+class TestGetLastTimestamp:
+    def test_returns_value_if_parameter_found(self, mock_params):
+        test_name = "Test-parameter"
+        test_value = datetime(2023, 10, 10, 11, 30, 30)
+        mock_params.put_parameter(
+            Name=test_name,
+            Value="2023-10-10 11:30:30",
+            Overwrite=True,
+        )
+        assert get_last_timestamp(test_name) == test_value
+
+    def test_raises_error_if_parameter_not_found(self, mock_params):
+        test_name = "Test-parameter"
+        with pytest.raises(ClientError) as excinfo:
+            get_last_timestamp(test_name)
+        assert str(excinfo.value) == (
+            "An error occurred (ParameterNotFound) "
+            + "when calling the GetParameter operation: "
+            + f"Parameter {test_name} not found."
+        )
+
+
+class TestWriteCurrentTimestamp:
+    def test_returns_correct_status_response_when_successful(
+            self, mock_params
+            ):
+        test_name = "Test-parameter"
+        test_value = datetime(2025, 10, 10, 11, 30, 30)
+        response = write_current_timestamp(test_name, test_value)
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        output = mock_params.get_parameter(
+            Name=test_name
+            )["Parameter"]["Value"]
+        assert output == "2025-10-10 11:30:30"
+
+    def test_overwrites_existing_parameter(self, mock_params):
+        test_name = "Test-parameter"
+        test_value_1 = datetime(2025, 10, 10, 11, 30, 30)
+        test_value_2 = datetime(1999, 4, 10, 6, 30, 30)
+        write_current_timestamp(test_name, test_value_1)
+        response = write_current_timestamp(test_name, test_value_2)
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        output = mock_params.get_parameter(
+            Name=test_name
+            )["Parameter"]["Value"]
+        assert output == "1999-04-10 06:30:30"


### PR DESCRIPTION
Added two new function: get_last_timestamp & write_last_timestamp.
The function read and write (respectively) a string representation of a datetime object as a parameter in AWS SSM.

The datetime object is required by the Ingestion/Extraction lambda to identify which database entries have been added since the previous time when the function was invoked.

The functions do not contain error handling within themselves. All error handling will be carried out in the main lambda handler function, within which they are called.